### PR TITLE
add bcalm installation to installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ conda activate space
 
 Then execute:
 ```
+conda install -y snakemake bcalm
+
 pip install Cython
 pip install https://github.com/dib-lab/pybbhash/archive/spacegraphcats.zip
 pip install https://github.com/dib-lab/khmer/archive/master.zip


### PR DESCRIPTION
There is a line installing bcalm to the twofoo spacegraphcats example in this readme: https://github.com/spacegraphcats/spacegraphcats-twofoo-example

Initially the readme instructions for this document weren't working, but after adding the bcalm install they worked. So, I'm assuming that they belong here?

Also hi to whoever sees this! 